### PR TITLE
slight reversions, and corrections

### DIFF
--- a/x-pack/examples/screenshotting_example/server/plugin.ts
+++ b/x-pack/examples/screenshotting_example/server/plugin.ts
@@ -34,7 +34,6 @@ export class ScreenshottingExamplePlugin implements Plugin<void, void> {
           screenshotting.getScreenshots({
             request,
             expression: request.query.expression,
-            urls: [],
           })
         );
 

--- a/x-pack/plugins/reporting/server/export_types/common/get_full_urls.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/get_full_urls.ts
@@ -13,24 +13,22 @@ import {
 } from 'url';
 import { ReportingConfigType } from '../../config';
 import { ReportingServerInfo } from '../../core';
-// import { TaskPayloadPNG } from '../png/types';
+import { TaskPayloadPNG } from '../png/types';
 import { TaskPayloadPDF } from '../printable_pdf/types';
 import { getAbsoluteUrlFactory } from './get_absolute_url';
 import { validateUrls } from './validate_urls';
 
-// @TODO removing code that isn't typed with PDF_v2 for type check passing
-
-// function isPngJob(job: TaskPayloadPNG | TaskPayloadPDF): job is TaskPayloadPNG {
-//   return (job as TaskPayloadPNG).relativeUrl !== undefined;
-// }
-function isPdfJob(job: TaskPayloadPDF): job is TaskPayloadPDF {
+function isPngJob(job: TaskPayloadPNG | TaskPayloadPDF): job is TaskPayloadPNG {
+  return (job as TaskPayloadPNG).relativeUrl !== undefined;
+}
+function isPdfJob(job: TaskPayloadPNG | TaskPayloadPDF): job is TaskPayloadPDF {
   return (job as TaskPayloadPDF).objects !== undefined;
 }
 
 export function getFullUrls(
   serverInfo: ReportingServerInfo,
   config: ReportingConfigType,
-  job: TaskPayloadPDF
+  job: TaskPayloadPDF | TaskPayloadPNG
 ) {
   const {
     kibanaServer: { protocol, hostname, port },
@@ -45,10 +43,9 @@ export function getFullUrls(
   // PDF and PNG job params put in the url differently
   let relativeUrls: string[] = [];
 
-  // if (isPngJob(job)) {
-  //   relativeUrls = [job.relativeUrl];
-  // } else
-  if (isPdfJob(job)) {
+  if (isPngJob(job)) {
+    relativeUrls = [job.relativeUrl];
+  } else if (isPdfJob(job)) {
     relativeUrls = job.objects.map((obj) => obj.relativeUrl);
   } else {
     throw new Error(

--- a/x-pack/plugins/reporting/server/export_types/common/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/index.ts
@@ -72,13 +72,8 @@ export abstract class ExportType<
   abstract createJob: CreateJobFn<JobParamsType>;
   abstract runTask: RunTaskFn<TaskPayloadType>;
 
-  public validLicenses: LicenseType[] = [
-    LICENSE_TYPE_TRIAL,
-    LICENSE_TYPE_CLOUD_STANDARD,
-    LICENSE_TYPE_GOLD,
-    LICENSE_TYPE_PLATINUM,
-    LICENSE_TYPE_ENTERPRISE,
-  ];
+  abstract validLicenses: LicenseType[];
+
   public setupDeps!: ExportTypeSetupDeps;
   public startDeps!: ExportTypeStartDeps;
   public http!: HttpServiceSetup;
@@ -126,13 +121,13 @@ export abstract class ExportType<
 
   public async getUiSettingsClient(request: KibanaRequest, logger = this.logger) {
     const spacesService = this.setupDeps.spaces?.spacesService;
-    const spaceId = await this.getSpaceId(request, logger);
+    const spaceId = this.getSpaceId(request, logger);
 
     if (spacesService && spaceId) {
       logger.info(`Creating UI Settings Client for space: ${spaceId}`);
     }
     const savedObjectsClient = await this.getSavedObjectsClient(request);
-    return await this.getUiSettingsServiceFactory(savedObjectsClient);
+    return this.getUiSettingsServiceFactory(savedObjectsClient);
   }
 
   public getFakeRequest(

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/index.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/index.test.ts
@@ -41,7 +41,8 @@ const getBasePayload = (baseObj: any) =>
     ...baseObj,
   } as TaskPayloadPDFV2);
 
-beforeAll(async () => {
+beforeEach(async () => {
+  content = '';
   stream = { write: jest.fn((chunk) => (content += chunk)) } as unknown as typeof stream;
 
   const configType = createMockConfigSchema({ encryptionKey: mockEncryptionKey });
@@ -62,10 +63,7 @@ beforeAll(async () => {
   });
 });
 
-beforeEach(() => {
-  // clear content from previous test
-  content = '';
-});
+afterEach(() => (generatePdfObservable as jest.Mock).mockReset());
 
 test(`passes browserTimezone to generatePdf`, async () => {
   const encryptedHeaders = await encryptHeaders({});
@@ -73,6 +71,7 @@ test(`passes browserTimezone to generatePdf`, async () => {
 
   const browserTimezone = 'UTC';
   await mockPdfExportType.runTask(
+    'pdfJobId',
     getBasePayload({
       forceNow: 'test',
       title: 'PDF Params Timezone Test',
@@ -80,7 +79,6 @@ test(`passes browserTimezone to generatePdf`, async () => {
       browserTimezone,
       headers: encryptedHeaders,
     }),
-    'pdfJobId',
     cancellationToken,
     stream
   );
@@ -101,8 +99,8 @@ test(`returns content_type of application/pdf`, async () => {
   (generatePdfObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from('') }));
 
   const { content_type: contentType } = await mockPdfExportType.runTask(
-    getBasePayload({ locatorParams: [], headers: encryptedHeaders }),
     'pdfJobId',
+    getBasePayload({ locatorParams: [], headers: encryptedHeaders }),
     cancellationToken,
     stream
   );
@@ -115,8 +113,8 @@ test(`returns content of generatePdf getBuffer base64 encoded`, async () => {
 
   const encryptedHeaders = await encryptHeaders({});
   await mockPdfExportType.runTask(
-    getBasePayload({ locatorParams: [], headers: encryptedHeaders }),
     'pdfJobId',
+    getBasePayload({ locatorParams: [], headers: encryptedHeaders }),
     cancellationToken,
     stream
   );

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
@@ -22,9 +22,7 @@ interface PdfResult {
   warnings: string[];
 }
 
-export type GetScreenshotsFn = (
-  options: PdfScreenshotOptions
-) => Rx.Observable<PdfScreenshotResult>;
+type GetScreenshotsFn = (options: PdfScreenshotOptions) => Rx.Observable<PdfScreenshotResult>;
 
 export function generatePdfObservable(
   config: ReportingConfigType,

--- a/x-pack/plugins/reporting/server/lib/tasks/execute_report.test.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/execute_report.test.ts
@@ -89,7 +89,6 @@ describe('Execute Report Task', () => {
       name: 'Noop',
       setup: jest.fn(),
       start: jest.fn(),
-      getSpaceId: jest.fn(),
       createJob: () => new Promise(() => {}),
       runTask: () => new Promise(() => {}),
       jobContentExtension: 'pdf',

--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -36,8 +36,6 @@ export class ReportingPlugin
 {
   private logger: Logger;
   private reportingCore?: ReportingCore;
-  // // private pdfExport?: PdfExportType;
-  // private exportTypesRegistry: ExportTypesRegistry = new ExportTypesRegistry();
 
   constructor(private initContext: PluginInitializerContext<ReportingConfigType>) {
     this.logger = initContext.logger.get();
@@ -62,15 +60,6 @@ export class ReportingPlugin
     // Usage counter for reporting telemetry
     const usageCounter = plugins.usageCollection?.createUsageCounter(PLUGIN_ID);
 
-    // this.pdfExport = new PdfExportType(
-    //   core,
-    //   reportingCore.getConfig(),
-    //   this.logger,
-    //   this.initContext
-    // );
-
-    // this.exportTypesRegistry.register(this.pdfExport);
-
     reportingCore.pluginSetup({
       logger: this.logger,
       status,
@@ -78,8 +67,6 @@ export class ReportingPlugin
       router: http.createRouter<ReportingRequestHandlerContext>(),
       usageCounter,
       docLinks: core.docLinks,
-      // pdfExport: this.pdfExport,
-      // exportTypesRegistry: this.exportTypesRegistry,
       ...plugins,
     });
 

--- a/x-pack/plugins/reporting/server/routes/lib/request_handler.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/request_handler.ts
@@ -45,7 +45,7 @@ export class RequestHandler {
   }
 
   public async enqueueJob(exportTypeId: string, jobParams: BaseParams) {
-    const { reporting, logger, context, user, req } = this;
+    const { reporting, logger, context, req, user } = this;
 
     const exportType = reporting.getExportTypesRegistry().getById(exportTypeId);
 
@@ -56,14 +56,16 @@ export class RequestHandler {
     const store = await reporting.getStore();
 
     if (!exportType.createJob) {
-      throw new Error(`Export type ${exportTypeId} is not an async job type!`);
+      throw new Error(`Export type ${exportTypeId} is not a valid instance!`);
     }
 
-    // 1. ensure the incoming params have a version field (should be set by the UI)
+    // 1. Ensure the incoming params have a version field (should be set by the UI)
     jobParams.version = checkParamsVersion(jobParams, logger);
-    // 2. encrypt request headers for the running report job to authenticate itself with Kibana
+
+    // 2. Encrypt request headers to store for the running report job to authenticate itself with Kibana
     const headers = await this.encryptHeaders();
 
+    // 3. Create a payload object by calling exportType.createJob(), and adding some automatic parameters
     const job = exportType.createJob(jobParams, context, req);
 
     const payload = {

--- a/x-pack/plugins/reporting/server/types.ts
+++ b/x-pack/plugins/reporting/server/types.ts
@@ -64,8 +64,8 @@ export type CreateJobFn<JobParamsType> = (
 ) => JobParamsType & { isDeprecated: boolean; browserTimezone: any };
 
 export type RunTaskFn<TaskPayloadType> = (
-  payload: TaskPayloadType,
   jobId: string,
+  payload: TaskPayloadType,
   cancellationToken: CancellationToken,
   stream: Writable
 ) => Promise<TaskRunResult>;

--- a/x-pack/plugins/screenshotting/server/screenshots/index.ts
+++ b/x-pack/plugins/screenshotting/server/screenshots/index.ts
@@ -8,6 +8,7 @@
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { HttpServiceSetup, KibanaRequest, Logger, PackageInfo } from '@kbn/core/server';
 import type { ExpressionAstExpression } from '@kbn/expressions-plugin/common';
+import type { Optional } from '@kbn/utility-types';
 import { Semaphore } from '@kbn/std';
 import ipaddr from 'ipaddr.js';
 import { defaultsDeep, sum } from 'lodash';
@@ -49,7 +50,7 @@ import { ScreenshotObservableHandler, UrlOrUrlWithContext } from './observable';
 
 export type { ScreenshotObservableResult, UrlOrUrlWithContext } from './observable';
 
-export interface CaptureOptions extends ScreenshotObservableOptions {
+export interface CaptureOptions extends Optional<ScreenshotObservableOptions, 'urls'> {
   /**
    * Expression to render. Mutually exclusive with `urls`.
    */


### PR DESCRIPTION
## Summary

These changes have a few goals:
1. restore parts of the code from `main` that don't need to change in this feature branch.
2. make some corrections to the PdfExportType class: it needs to have a constructor that calls `super()` on the parent class, and it needs to declare it's own valid license types
  - the subclasses do not need to expose their own `setup` and `start` methods since they are provided in the superclass.